### PR TITLE
Fix layout of MultiWaveView and GlowPadView.

### DIFF
--- a/core/java/com/android/internal/widget/multiwaveview/GlowPadView.java
+++ b/core/java/com/android/internal/widget/multiwaveview/GlowPadView.java
@@ -1116,17 +1116,13 @@ public class GlowPadView extends View {
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-        final int width = right - left;
-        final int height = bottom - top;
 
         // Target placement width/height. This puts the targets on the greater of the ring
         // width or the specified outer radius.
         final float placementWidth = getRingWidth();
         final float placementHeight = getRingHeight();
-        float newWaveCenterX = mHorizontalInset
-                + Math.max(width, mMaxTargetWidth + placementWidth) / 2;
-        float newWaveCenterY = mVerticalInset
-                + Math.max(height, + mMaxTargetHeight + placementHeight) / 2;
+        float newWaveCenterX = mHorizontalInset + (mMaxTargetWidth + placementWidth) / 2;
+        float newWaveCenterY = mVerticalInset + (mMaxTargetHeight + placementHeight) / 2;
 
         if (mInitialLayout) {
             stopAndHideWaveAnimation();


### PR DESCRIPTION
If the calculated size of the rings is much smaller than the measured
size (which is happening e.g. on mdpi 600x1024 tablets), the glow pad
appeared shifted to the right.
This happened due to the insets being calculated as difference of
available and needed size, and later on being added to the available
size. Example numbers (Nexus 4 with density forced to 160):
- computed size in onMeasure: 768x505
- scaled size in onMeasure: 505x505
- thus, insets are calculated as 131/0
- in onLayout, placementWidth (364) and max target width (108) are much
  smaller than width (768)
- thus, center is calculated as 131 + (768 / 2) = 515, thus shifted to
  the right

Fix that by not using width in the calculation, as the inset size
already takes it into consideration.

JIRA:CYAN-829
Change-Id: Ifc2a93214f812f554a8fed3243eed66aec9f00c9