### PR TITLE
Frameworks: Add per app controls for LP keyguard notifications (1/2)

### DIFF
--- a/core/java/android/app/INotificationManager.aidl
+++ b/core/java/android/app/INotificationManager.aidl
@@ -51,6 +51,9 @@ interface INotificationManager
     void setPackageVisibilityOverride(String pkg, int uid, int visibility);
     int getPackageVisibilityOverride(String pkg, int uid);
 
+    void setShowNotificationForPackageOnKeyguard(String pkg, int uid, int status);
+    int getShowNotificationForPackageOnKeyguard(String pkg, int uid);
+
     // TODO: Remove this when callers have been migrated to the equivalent
     // INotificationListener method.
     StatusBarNotification[] getActiveNotifications(String callingPkg);

--- a/core/java/android/app/Notification.java
+++ b/core/java/android/app/Notification.java
@@ -510,6 +510,21 @@ public class Notification implements Parcelable
     public int priority;
 
     /**
+     * Default.
+     * Show all notifications from an app on keyguard.
+     *
+     * @hide
+     */
+    public static final int SHOW_ALL_NOTI_ON_KEYGUARD = 0x01;
+
+    /**
+     * Show only notifications from an app which are not ongoing ones.
+     *
+     * @hide
+     */
+    public static final int SHOW_NO_ONGOING_NOTI_ON_KEYGUARD = 0x02;
+
+    /**
      * Accent color (an ARGB integer like the constants in {@link android.graphics.Color})
      * to be applied by the standard Style templates when presenting this notification.
      *

--- a/core/java/android/app/NotificationManager.java
+++ b/core/java/android/app/NotificationManager.java
@@ -17,6 +17,7 @@
 package android.app;
 
 import android.annotation.SdkConstant;
+import android.app.Notification;
 import android.app.Notification.Builder;
 import android.content.ComponentName;
 import android.content.Context;
@@ -261,6 +262,18 @@ public class NotificationManager
             return service.matchesCallFilter(extras);
         } catch (RemoteException e) {
             return false;
+        }
+    }
+
+    /**
+     * @hide
+     */
+    public int getShowNotificationForPackageOnKeyguard(String pkg, int uid) {
+        INotificationManager service = getService();
+        try {
+            return getService().getShowNotificationForPackageOnKeyguard(pkg, uid);
+        } catch (RemoteException e) {
+            return Notification.SHOW_ALL_NOTI_ON_KEYGUARD;
         }
     }
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/BaseStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/BaseStatusBar.java
@@ -214,6 +214,8 @@ public abstract class BaseStatusBar extends SystemUI implements
     protected WindowManager mWindowManager;
     protected IWindowManager mWindowManagerService;
 
+    private NotificationManager mNoMan;
+
     protected abstract void refreshLayout(int layoutDirection);
 
     protected Display mDisplay;
@@ -348,9 +350,7 @@ public abstract class BaseStatusBar extends SystemUI implements
                 updateLockscreenNotificationSetting();
                 updateNotifications();
             } else if (BANNER_ACTION_CANCEL.equals(action) || BANNER_ACTION_SETUP.equals(action)) {
-                NotificationManager noMan = (NotificationManager)
-                        mContext.getSystemService(Context.NOTIFICATION_SERVICE);
-                noMan.cancel(HIDDEN_NOTIFICATION_ID);
+                mNoMan.cancel(HIDDEN_NOTIFICATION_ID);
 
                 Settings.Secure.putInt(mContext.getContentResolver(),
                         Settings.Secure.SHOW_NOTE_ABOUT_NOTIFICATION_HIDING, 0);
@@ -458,6 +458,9 @@ public abstract class BaseStatusBar extends SystemUI implements
     public void start() {
         mWindowManager = (WindowManager)mContext.getSystemService(Context.WINDOW_SERVICE);
         mWindowManagerService = WindowManagerGlobal.getWindowManagerService();
+
+        mNoMan = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
+
         mDisplay = mWindowManager.getDefaultDisplay();
         mDevicePolicyManager = (DevicePolicyManager)mContext.getSystemService(
                 Context.DEVICE_POLICY_SERVICE);
@@ -617,9 +620,7 @@ public abstract class BaseStatusBar extends SystemUI implements
                             mContext.getString(R.string.hidden_notifications_setup),
                             setupIntent);
 
-            NotificationManager noMan =
-                    (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
-            noMan.notify(HIDDEN_NOTIFICATION_ID, note.build());
+            mNoMan.notify(HIDDEN_NOTIFICATION_ID, note.build());
         }
     }
 
@@ -1734,7 +1735,16 @@ public abstract class BaseStatusBar extends SystemUI implements
     }
 
     private boolean shouldShowOnKeyguard(StatusBarNotification sbn) {
-        return mShowLockscreenNotifications && !mNotificationData.isAmbient(sbn.getKey());
+        final int showOnKeyguard = mNoMan.getShowNotificationForPackageOnKeyguard(
+                sbn.getPackageName(), sbn.getUid());
+        boolean isKeyguardAllowedForApp =
+                (showOnKeyguard & Notification.SHOW_ALL_NOTI_ON_KEYGUARD) != 0;
+        if (isKeyguardAllowedForApp && sbn.isOngoing()) {
+            isKeyguardAllowedForApp =
+                    (showOnKeyguard & Notification.SHOW_NO_ONGOING_NOTI_ON_KEYGUARD) == 0;
+        }
+        return mShowLockscreenNotifications && !mNotificationData.isAmbient(sbn.getKey())
+                && isKeyguardAllowedForApp;
     }
 
     protected void setZenMode(int mode) {

--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -1257,6 +1257,20 @@ public class NotificationManagerService extends SystemService {
             return mRankingHelper.getPackageVisibilityOverride(pkg, uid);
         }
 
+        @Override
+        public void setShowNotificationForPackageOnKeyguard(
+                String pkg, int uid, int status) {
+            checkCallerIsSystem();
+            mRankingHelper.setShowNotificationForPackageOnKeyguard(pkg, uid, status);
+            savePolicyFile();
+        }
+
+        @Override
+        public int getShowNotificationForPackageOnKeyguard(String pkg, int uid) {
+            enforceSystemOrSystemUI("INotificationManager.getShowNotificationForPackageOnKeyguard");
+            return mRankingHelper.getShowNotificationForPackageOnKeyguard(pkg, uid);
+        }
+
         /**
          * System-only API for getting a list of current (i.e. not cleared) notifications.
          *

--- a/services/core/java/com/android/server/notification/RankingConfig.java
+++ b/services/core/java/com/android/server/notification/RankingConfig.java
@@ -23,4 +23,9 @@ public interface RankingConfig {
     int getPackageVisibilityOverride(String packageName, int uid);
 
     void setPackageVisibilityOverride(String packageName, int uid, int visibility);
+
+    void setShowNotificationForPackageOnKeyguard(String packageName, int uid, int status);
+
+    int getShowNotificationForPackageOnKeyguard(String packageName, int uid);
+
 }

--- a/services/core/java/com/android/server/notification/RankingHelper.java
+++ b/services/core/java/com/android/server/notification/RankingHelper.java
@@ -52,6 +52,7 @@ public class RankingHelper implements RankingConfig {
     private static final String ATT_UID = "uid";
     private static final String ATT_PRIORITY = "priority";
     private static final String ATT_VISIBILITY = "visibility";
+    private static final String ATT_KEYGUARD = "keyguard";
 
     private final NotificationSignalExtractor[] mSignalExtractors;
     private final NotificationComparator mPreliminaryComparator = new NotificationComparator();
@@ -60,6 +61,7 @@ public class RankingHelper implements RankingConfig {
     // Package name to uid, to priority. Would be better as Table<String, Int, Int>
     private final ArrayMap<String, SparseIntArray> mPackagePriorities;
     private final ArrayMap<String, SparseIntArray> mPackageVisibilities;
+    private final ArrayMap<String, SparseIntArray> mPackageOnKeyguard;
     private final ArrayMap<String, NotificationRecord> mProxyByGroupTmp;
 
     private final Context mContext;
@@ -70,6 +72,7 @@ public class RankingHelper implements RankingConfig {
         mRankingHandler = rankingHandler;
         mPackagePriorities = new ArrayMap<String, SparseIntArray>();
         mPackageVisibilities = new ArrayMap<String, SparseIntArray>();
+        mPackageOnKeyguard = new ArrayMap<String, SparseIntArray>();
 
         final int N = extractorNames.length;
         mSignalExtractors = new NotificationSignalExtractor[N];
@@ -139,6 +142,8 @@ public class RankingHelper implements RankingConfig {
                     int priority = safeInt(parser, ATT_PRIORITY, Notification.PRIORITY_DEFAULT);
                     int vis = safeInt(parser, ATT_VISIBILITY,
                             NotificationListenerService.Ranking.VISIBILITY_NO_OVERRIDE);
+                    int keyguard = safeInt(parser, ATT_KEYGUARD,
+                            Notification.SHOW_ALL_NOTI_ON_KEYGUARD);
                     String name = parser.getAttributeValue(null, ATT_NAME);
 
                     if (!TextUtils.isEmpty(name)) {
@@ -158,6 +163,14 @@ public class RankingHelper implements RankingConfig {
                             }
                             visibilityByUid.put(uid, vis);
                         }
+                        if (keyguard != Notification.SHOW_ALL_NOTI_ON_KEYGUARD) {
+                            SparseIntArray keyguardByUid = mPackageOnKeyguard.get(name);
+                            if (keyguardByUid == null) {
+                                keyguardByUid = new SparseIntArray();
+                                mPackageOnKeyguard.put(name, keyguardByUid);
+                            }
+                            keyguardByUid.put(uid, keyguard);
+                        }
                     }
                 }
             }
@@ -173,11 +186,14 @@ public class RankingHelper implements RankingConfig {
                 + mPackageVisibilities.size());
         packageNames.addAll(mPackagePriorities.keySet());
         packageNames.addAll(mPackageVisibilities.keySet());
+        packageNames.addAll(mPackageOnKeyguard.keySet());
         final Set<Integer> packageUids = new ArraySet<>();
         for (String packageName : packageNames) {
             packageUids.clear();
             SparseIntArray priorityByUid = mPackagePriorities.get(packageName);
             SparseIntArray visibilityByUid = mPackageVisibilities.get(packageName);
+            SparseIntArray keyguardByUid = mPackageOnKeyguard.get(packageName);
+
             if (priorityByUid != null) {
                 final int M = priorityByUid.size();
                 for (int j = 0; j < M; j++) {
@@ -188,6 +204,12 @@ public class RankingHelper implements RankingConfig {
                 final int M = visibilityByUid.size();
                 for (int j = 0; j < M; j++) {
                     packageUids.add(visibilityByUid.keyAt(j));
+                }
+            }
+            if (keyguardByUid != null) {
+                final int M = keyguardByUid.size();
+                for (int j = 0; j < M; j++) {
+                    packageUids.add(keyguardByUid.keyAt(j));
                 }
             }
             for (Integer uid : packageUids) {
@@ -203,6 +225,12 @@ public class RankingHelper implements RankingConfig {
                     final int visibility = visibilityByUid.get(uid);
                     if (visibility != NotificationListenerService.Ranking.VISIBILITY_NO_OVERRIDE) {
                         out.attribute(null, ATT_VISIBILITY, Integer.toString(visibility));
+                    }
+                }
+                if (keyguardByUid != null) {
+                    final int keyguard = keyguardByUid.get(uid);
+                    if (keyguard != Notification.SHOW_ALL_NOTI_ON_KEYGUARD) {
+                        out.attribute(null, ATT_KEYGUARD, Integer.toString(keyguard));
                     }
                 }
                 out.attribute(null, ATT_UID, Integer.toString(uid));
@@ -357,6 +385,31 @@ public class RankingHelper implements RankingConfig {
             mPackageVisibilities.put(packageName, visibilityByUid);
         }
         visibilityByUid.put(uid, visibility);
+        updateConfig();
+    }
+
+    @Override
+    public int getShowNotificationForPackageOnKeyguard(String packageName, int uid) {
+        int keyguard = Notification.SHOW_ALL_NOTI_ON_KEYGUARD;
+        SparseIntArray keyguardByUid = mPackageOnKeyguard.get(packageName);
+        if (keyguardByUid != null) {
+            keyguard = keyguardByUid.get(uid, Notification.SHOW_ALL_NOTI_ON_KEYGUARD);
+        }
+        return keyguard;
+    }
+
+    @Override
+    public void setShowNotificationForPackageOnKeyguard(
+                String packageName, int uid, int keyguard) {
+        if (keyguard == getShowNotificationForPackageOnKeyguard(packageName, uid)) {
+            return;
+        }
+        SparseIntArray keyguardByUid = mPackageOnKeyguard.get(packageName);
+        if (keyguardByUid == null) {
+            keyguardByUid = new SparseIntArray();
+            mPackageOnKeyguard.put(packageName, keyguardByUid);
+        }
+        keyguardByUid.put(uid, keyguard);
         updateConfig();
     }
 


### PR DESCRIPTION
Nice done by google but the UX is a problem especially for ppl who are using a lot apps and just want
to see from important apps the notifications on the lockscreen.

This commit adds the ability to

- enable/disable per app the keyguard notification at all
- enable/disable per app ongoing notifications on the keyguard

We handle this over the app policy conf file like the other per app notification options.

Change-Id: I1064765428ac5e857cb441c121ece63d33747171