### PR TITLE
systemui: Fix NPE in ExpandHelper

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/ExpandHelper.java
+++ b/packages/SystemUI/src/com/android/systemui/ExpandHelper.java
@@ -351,7 +351,9 @@ public class ExpandHelper implements Gefingerpoken {
                 mVelocityTracker.addMovement(event);
                 break;
             case MotionEvent.ACTION_MOVE:
-                mVelocityTracker.addMovement(event);
+                if (mVelocityTracker != null) {
+                    mVelocityTracker.addMovement(event);
+                }
                 break;
             default:
                 break;


### PR DESCRIPTION
 * NPE was seen after first boot, no clear way to reproduce. ACTION_DOWN
   in this method indicated that mVelocityTracker might possibly be
   null, so ignore the movement if necessary.

Change-Id: I3fbe277718d50641e2dcb272132e70fed0e0ddc1