### PR TITLE
Hide privacyguard notifications on keyguard

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/BaseStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/BaseStatusBar.java
@@ -1738,8 +1738,15 @@ public abstract class BaseStatusBar extends SystemUI implements
         if (!mShowLockscreenNotifications || mNotificationData.isAmbient(sbn.getKey())) {
             return false;
         }
+        final String pkgName = sbn.getPackageName();
+        // always hide privacy guard notification on lock screen
+        if (pkgName.equals("android") &&
+                sbn.getId() == com.android.internal.R.string.privacy_guard_notification) {
+            return false;
+        }
+        // retrieve per app visibility setting
         final int showOnKeyguard = mNoMan.getShowNotificationForPackageOnKeyguard(
-                sbn.getPackageName(), sbn.getUid());
+                pkgName, sbn.getUid());
         boolean isKeyguardAllowedForApp =
                 (showOnKeyguard & Notification.SHOW_ALL_NOTI_ON_KEYGUARD) != 0;
         if (isKeyguardAllowedForApp && sbn.isOngoing()) {


### PR DESCRIPTION
They were never deliberately put there it just
happened as a default behaviour.  There's no
purpose served showing them on keyguard other
than to waste screen real estate.

Change-Id: I8c8f93e122a2b71ae7aadd7a49baaf7f139ecfbc