### PR TITLE
ActivityManager: Fix monkey tests

### DIFF
--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -15433,7 +15433,7 @@ public final class ActivityManagerService extends ActivityManagerNative
             }
             BroadcastFilter bf = new BroadcastFilter(filter, rl, callerPackage,
                     permission, callingUid, userId,
-                    (callerApp.info.flags & ApplicationInfo.FLAG_SYSTEM) != 0);
+                    (callerApp != null && callerApp.info != null && (callerApp.info.flags & ApplicationInfo.FLAG_SYSTEM) != 0));
             rl.add(bf);
             if (!bf.debugCheck()) {
                 Slog.w(TAG, "==> For Dynamic broadast");


### PR DESCRIPTION
Change I30e38c6c27d339d55a8f9a0f4106185356a9b9a0 (adding ordered
broadcast prioritization) adds the assumption that every broadcast
generator has a full-fledged caller app, which isn't true for
monkey-created tests. Make sure the caller is a full app before
checking if it is AID_SYSTEM to avoid an NPE

Fixes com.android.cts.monkey.*

Change-Id: Ide0dd046c6c5eb10ab4acb504237b58cbbbd8cfa