### PR TITLE
Prevent power key capture when screen is off

### DIFF
--- a/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
+++ b/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
@@ -5176,7 +5176,8 @@ public class PhoneWindowManager implements WindowManagerPolicy {
             case KeyEvent.KEYCODE_POWER: {
                 if (mTopFullscreenOpaqueWindowState != null &&
                         (mTopFullscreenOpaqueWindowState.getAttrs().privateFlags
-                        & WindowManager.LayoutParams.PRIVATE_FLAG_PREVENT_POWER_KEY) != 0){
+                        & WindowManager.LayoutParams.PRIVATE_FLAG_PREVENT_POWER_KEY) != 0
+                        && mScreenOnFully){
                     return result;
                 }
                 result &= ~ACTION_PASS_TO_USER;


### PR DESCRIPTION
The ability for an activity to capture the power key, which was
added to support power key as shutter in the camera, should only
allow the capture when the screen is on. Otherwise, if an activity
that captures the power key is to the front when the device turns
off, the user will be unable to turn it back on.

Change-Id: Ib119d6914ec72554b404c1cc17eef3a932d5d402